### PR TITLE
Add simple transcoding with streamio-ffmpeg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.ruby-version
+*.mp4

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ ruby '2.4.1'
 
 gem 'thor'
 gem 'streamio-ffmpeg'
+gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.2)
+    method_source (0.9.0)
     multi_json (1.12.2)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     streamio-ffmpeg (3.0.2)
       multi_json (~> 1.8)
     thor (0.20.0)
@@ -10,6 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  pry
   streamio-ffmpeg
   thor
 
@@ -17,4 +23,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.14.6
+   1.16.0

--- a/helpers/file_helpers.rb
+++ b/helpers/file_helpers.rb
@@ -1,0 +1,7 @@
+module FileHelpers
+  def self.out_path(in_path)
+    path = File.dirname(in_path)
+    filename = File.basename(in_path, ".*")
+    return "#{path}/#{filename}.mp4"
+  end
+end

--- a/screencastr.thor
+++ b/screencastr.thor
@@ -2,6 +2,8 @@ require 'thor'
 require 'streamio-ffmpeg'
 require 'pry'
 
+require_relative 'helpers/file_helpers'
+
 class Screencastr < Thor
   # Flow
   # 1. Open video
@@ -26,9 +28,6 @@ class Screencastr < Thor
   desc "transcode VIDEO_PATH", "Transcode video file to mp4 format"
   def transcode(video_path)
     video = FFMPEG::Movie.new(video_path)
-    path_array = video_path.split('/')
-    filename = path_array.pop.split('.').first
-    path = path_array.join('/')
-    video.transcode("#{path}/#{filename}.mp4")
+    video.transcode(FileHelpers.out_path(video_path))
   end
 end

--- a/screencastr.thor
+++ b/screencastr.thor
@@ -1,5 +1,6 @@
 require 'thor'
 require 'streamio-ffmpeg'
+require 'pry'
 
 class Screencastr < Thor
   # Flow
@@ -13,12 +14,21 @@ class Screencastr < Thor
     # a. Will need a naming scheme to match the location properly
 
   desc "add_bumpers VIDEO_PATH", "Add bumpers to video"
-  def add_bumpers(video)
+  def add_bumpers(video_path)
     video = FFMPEG::Movie.new(video_path)
   end
 
   desc "add_watermark VIDEO_PATH", "Add watermark to video"
-  def add_watermark(video)
+  def add_watermark(video_path)
     video = FFMPEG::Movie.new(video_path)
+  end
+
+  desc "transcode VIDEO_PATH", "Transcode video file to mp4 format"
+  def transcode(video_path)
+    video = FFMPEG::Movie.new(video_path)
+    path_array = video_path.split('/')
+    filename = path_array.pop.split('.').first
+    path = path_array.join('/')
+    video.transcode("#{path}/#{filename}.mp4")
   end
 end


### PR DESCRIPTION
Added a `transcode` task. Takes a`video_path` as argument, transcodes the file to mp4 format, and saves it the same directory as the source file.

Its very optimistic, I haven't added any error handling or anything, and I've only tested it with a `.mov` file so far, but it works.