### PR TITLE
Add concat task

### DIFF
--- a/helpers/file_helpers.rb
+++ b/helpers/file_helpers.rb
@@ -4,4 +4,12 @@ module FileHelpers
     filename = File.basename(in_path, ".*")
     return "#{path}/#{filename}.mp4"
   end
+
+  def self.concat_out_path(first_in, second_in)
+    path = File.dirname(first_in)
+    first_filename = File.basename(first_in, ".*")
+    second_filename = File.basename(second_in, ".*")
+
+    return "#{path}/#{first_filename + second_filename}.mp4"
+  end
 end

--- a/helpers/file_helpers.rb
+++ b/helpers/file_helpers.rb
@@ -1,15 +1,10 @@
 module FileHelpers
-  def self.out_path(in_path)
-    path = File.dirname(in_path)
-    filename = File.basename(in_path, ".*")
-    return "#{path}/#{filename}.mp4"
+  def self.out_path(in_file, out_name)
+    path = File.dirname(in_file)
+    return "#{path}/dest/#{out_name}"
   end
 
-  def self.concat_out_path(first_in, second_in)
-    path = File.dirname(first_in)
-    first_filename = File.basename(first_in, ".*")
-    second_filename = File.basename(second_in, ".*")
-
-    return "#{path}/#{first_filename + second_filename}.mp4"
+  def self.generate_filename(files)
+    return files.reduce("") {|acc, f| acc + File.basename(f, ".*") } + ".mp4"
   end
 end

--- a/helpers/process_helpers.rb
+++ b/helpers/process_helpers.rb
@@ -1,0 +1,8 @@
+module ProcessHelpers
+  def self.resolution_require_value(option)
+    if option == "resolution"
+      puts "No value provided for option '--resolution'"
+      exit
+    end
+  end
+end

--- a/screencastr.thor
+++ b/screencastr.thor
@@ -25,8 +25,10 @@ class Screencastr < Thor
     video = FFMPEG::Movie.new(video_path)
 
     options = {
-      watermark: "assets/160-GA-Bitmaker-Glyph-Black.png", resolution: video.resolution,
-      watermark_filter: { position: "RB", padding_x: 30, padding_y: 30 }
+      watermark: "assets/160-GA-Bitmaker-Glyph-Black.png",
+      watermark_filter: { position: "RB", padding_x: 30, padding_y: 30 },
+      resolution: "1920x1080",
+      frame_rate: 30
     }
 
     video.transcode(FileHelpers.out_path(video_path), options)
@@ -35,6 +37,22 @@ class Screencastr < Thor
   desc "transcode VIDEO_PATH", "Transcode video file to mp4 format"
   def transcode(video_path)
     video = FFMPEG::Movie.new(video_path)
-    video.transcode(FileHelpers.out_path(video_path))
+
+    options = {
+      resolution: "1920x1080", frame_rate: 30
+    }
+
+    video.transcode(FileHelpers.out_path(video_path), options)
+  end
+
+  desc "concat FIRST_VIDEO SECOND_VIDEO", "Concatenate two video files together"
+  def concat(first_video, second_video)
+    out = FileHelpers.concat_out_path(first_video, second_video)
+
+    `ffmpeg -i #{first_video} -i #{second_video} \
+    -filter_complex '[0:v] scale=1920:1080 [vs0]; [1:v] scale=1920:1080 [vs1]; \
+    [vs0][0:a][vs1][1:a] concat=n=2:v=1:a=1 [vout][aout]' \
+    -r 30 \
+    -map '[vout]' -map '[aout]' #{out}`
   end
 end

--- a/screencastr.thor
+++ b/screencastr.thor
@@ -15,14 +15,14 @@ class Screencastr < Thor
   # 6. Upload video to S3
     # a. Will need a naming scheme to match the location properly
 
-  desc "add_bumpers VIDEO_PATH", "Add bumpers to video"
-  def add_bumpers(video_path)
-    video = FFMPEG::Movie.new(video_path)
+  desc "add_bumpers IN_FILE OUT_FILE", "Add bumpers to video"
+  def add_bumpers(in_file, out_file)
+    video = FFMPEG::Movie.new(in_file)
   end
 
-  desc "add_watermark VIDEO_PATH", "Add watermark to video"
-  def add_watermark(video_path)
-    video = FFMPEG::Movie.new(video_path)
+  desc "add_watermark IN_FILE OUT_FILE", "Add watermark to video"
+  def add_watermark(in_file, out_file)
+    video = FFMPEG::Movie.new(in_file)
 
     options = {
       watermark: "assets/160-GA-Bitmaker-Glyph-Black.png",
@@ -31,28 +31,26 @@ class Screencastr < Thor
       frame_rate: 30
     }
 
-    video.transcode(FileHelpers.out_path(video_path), options)
+    video.transcode(out_file, options)
   end
 
-  desc "transcode VIDEO_PATH", "Transcode video file to mp4 format"
-  def transcode(video_path)
-    video = FFMPEG::Movie.new(video_path)
+  desc "transcode IN_FILE OUT_FILE", "Transcode video file to mp4 format"
+  def transcode(in_file, out_file)
+    video = FFMPEG::Movie.new(in_file)
 
     options = {
       resolution: "1920x1080", frame_rate: 30
     }
 
-    video.transcode(FileHelpers.out_path(video_path), options)
+    video.transcode(out_file, options)
   end
 
-  desc "concat FIRST_VIDEO SECOND_VIDEO", "Concatenate two video files together"
-  def concat(first_video, second_video)
-    out = FileHelpers.concat_out_path(first_video, second_video)
-
-    `ffmpeg -i #{first_video} -i #{second_video} \
+  desc "concat FIRST_IN SECOND_IN OUT_FILE", "Concatenate two video files together"
+  def concat(first_in, second_in, out_file)
+    `ffmpeg -i #{first_in} -i #{second_in} \
     -filter_complex '[0:v] scale=1920:1080 [vs0]; [1:v] scale=1920:1080 [vs1]; \
     [vs0][0:a][vs1][1:a] concat=n=2:v=1:a=1 [vout][aout]' \
     -r 30 \
-    -map '[vout]' -map '[aout]' #{out}`
+    -map '[vout]' -map '[aout]' #{out_file}`
   end
 end

--- a/screencastr.thor
+++ b/screencastr.thor
@@ -3,6 +3,7 @@ require 'streamio-ffmpeg'
 require 'pry'
 
 require_relative 'helpers/file_helpers'
+require_relative 'helpers/process_helpers'
 
 class Screencastr < Thor
   # Flow
@@ -16,41 +17,56 @@ class Screencastr < Thor
     # a. Will need a naming scheme to match the location properly
 
   desc "add_bumpers IN_FILE OUT_FILE", "Add bumpers to video"
+  method_option :framerate, aliases: "-f", desc: "Specify a framerate for OUT_FILE, (eg. -f 30)", type: :numeric
+  method_option :resolution, aliases: "-r", desc: "Specify a resolution for OUT_FILE, (eg. -r 1920x1080)"
   def add_bumpers(in_file, out_file)
+    ProcessHelpers.resolution_require_value(options[:resolution])
     video = FFMPEG::Movie.new(in_file)
   end
 
   desc "add_watermark IN_FILE OUT_FILE", "Add watermark to video"
+  method_option :framerate, aliases: "-f", desc: "Specify a framerate for OUT_FILE, (eg. -f 30)", type: :numeric
+  method_option :resolution, aliases: "-r", desc: "Specify a resolution for OUT_FILE, (eg. -r 1920x1080)", type: :string
   def add_watermark(in_file, out_file)
+    ProcessHelpers.resolution_require_value(options[:resolution])
     video = FFMPEG::Movie.new(in_file)
 
     options = {
       watermark: "assets/160-GA-Bitmaker-Glyph-Black.png",
       watermark_filter: { position: "RB", padding_x: 30, padding_y: 30 },
-      resolution: "1920x1080",
-      frame_rate: 30
+      resolution: options[:resolution] || "1920x1080",
+      frame_rate: options[:framerate] || 30
     }
 
     video.transcode(out_file, options)
   end
 
   desc "transcode IN_FILE OUT_FILE", "Transcode video file to mp4 format"
+  method_option :framerate, aliases: "-f", desc: "Specify a framerate for OUT_FILE, (eg. -f 30)", type: :numeric
+  method_option :resolution, aliases: "-r", desc: "Specify a resolution for OUT_FILE, (eg. -r 1920x1080)", type: :string
   def transcode(in_file, out_file)
+    ProcessHelpers.resolution_require_value(options[:resolution])
     video = FFMPEG::Movie.new(in_file)
 
     options = {
-      resolution: "1920x1080", frame_rate: 30
+      resolution: options[:resolution] || "1920x1080",
+      frame_rate: options[:framerate] || 30
     }
 
     video.transcode(out_file, options)
   end
 
   desc "concat FIRST_IN SECOND_IN OUT_FILE", "Concatenate two video files together"
+  method_option :framerate, aliases: "-f", desc: "Specify a framerate for OUT_FILE, (eg. -f 30)", type: :numeric
+  method_option :resolution, aliases: "-r", desc: "Specify a resolution for OUT_FILE, (eg. -r 1920x1080)", type: :string
   def concat(first_in, second_in, out_file)
+    ProcessHelpers.resolution_require_value(options[:resolution])
+
     `ffmpeg -i #{first_in} -i #{second_in} \
-    -filter_complex '[0:v] scale=1920:1080 [vs0]; [1:v] scale=1920:1080 [vs1]; \
+    -filter_complex '[0:v] scale=#{options[:resolution] || "1920x1080"} [vs0]; \
+    [1:v] scale=#{options[:resolution] || "1920x1080"} [vs1]; \
     [vs0][0:a][vs1][1:a] concat=n=2:v=1:a=1 [vout][aout]' \
-    -r 30 \
+    -r #{options[:framerate] || 30} \
     -map '[vout]' -map '[aout]' #{out_file}`
   end
 end


### PR DESCRIPTION
Fixes #4. Alright, there's some shit going on here, let me break it down. 

+ The Streamio library doesn't support multiple inputs, so I'm just invoking `ffmpeg` directly.
+ Using the concat demuxer is fine so long as the files are the same resolution/format, but produces some wacky results if they aren't. So I decided to go with transcoding, even though its slower.
+ The transcoding is somewhat complicated, and uses `filter_complex`, which is the catchall way to do most complicated transcoding. First it scales both video streams from the videos to 1080p. Then it combines the scaled video streams and audio streams. 
+ After that, we set the frame rate to 30fps for the output.
+ Finally, we combine the names of both video files to get a filename for the new file, and save it.