### PR TITLE
Fill in add_bumpers, add brand task

### DIFF
--- a/screencastr.thor
+++ b/screencastr.thor
@@ -25,13 +25,13 @@ class Screencastr < Thor
     ext = File.extname(out_file)[1..-1]
 
     `ffmpeg -f lavfi -i anullsrc=channel_layout=stereo:sample_rate=44100 \
-    -loop 1 -i assets/1080-GA-Splash.png -f #{ext} -t 5 -r 30 -pix_fmt yuv420p \
+    -loop 1 -i assets/1080-GA-Splash.png -f #{ext} -t 5 -r #{options[:framerate] || 30} -pix_fmt yuv420p \
     -vf scale=#{options[:resolution] || "1920x1080"} -map 0:a -map 1:v bumper.#{ext}`
 
     # Can't use invoke, because Thor won't allow the same task to be invoked twice
-    s = Screencastr.new
-    s.options = options
     begin
+      s = Screencastr.new
+      s.options = options
       s.concat("bumper.#{ext}", in_file, "bumper-tmp.#{ext}")
       s.concat("bumper-tmp.#{ext}", "bumper.#{ext}", out_file)
     ensure

--- a/screencastr.thor
+++ b/screencastr.thor
@@ -16,49 +16,59 @@ class Screencastr < Thor
   # 6. Upload video to S3
     # a. Will need a naming scheme to match the location properly
 
+  class_option :framerate, aliases: "-f", desc: "Specify a framerate for OUT_FILE, (eg. -f 30)", type: :numeric
+  class_option :resolution, aliases: "-r", desc: "Specify a resolution for OUT_FILE, (eg. -r 1920x1080)", type: :string
+
   desc "add_bumpers IN_FILE OUT_FILE", "Add bumpers to video"
-  method_option :framerate, aliases: "-f", desc: "Specify a framerate for OUT_FILE, (eg. -f 30)", type: :numeric
-  method_option :resolution, aliases: "-r", desc: "Specify a resolution for OUT_FILE, (eg. -r 1920x1080)"
   def add_bumpers(in_file, out_file)
     ProcessHelpers.resolution_require_value(options[:resolution])
-    video = FFMPEG::Movie.new(in_file)
+    ext = File.extname(out_file)[1..-1]
+
+    `ffmpeg -f lavfi -i anullsrc=channel_layout=stereo:sample_rate=44100 \
+    -loop 1 -i assets/1080-GA-Splash.png -f #{ext} -t 5 -r 30 -pix_fmt yuv420p \
+    -vf scale=#{options[:resolution] || "1920x1080"} -map 0:a -map 1:v bumper.#{ext}`
+
+    # Can't use invoke, because Thor won't allow the same task to be invoked twice
+    s = Screencastr.new
+    s.options = options
+    begin
+      s.concat("bumper.#{ext}", in_file, "bumper-tmp.#{ext}")
+      s.concat("bumper-tmp.#{ext}", "bumper.#{ext}", out_file)
+    ensure
+      File.delete("bumper.#{ext}") if File.exists?("bumper.#{ext}")
+      File.delete("bumper-tmp.#{ext}") if File.exists?("bumper-tmp.#{ext}")
+    end
   end
 
   desc "add_watermark IN_FILE OUT_FILE", "Add watermark to video"
-  method_option :framerate, aliases: "-f", desc: "Specify a framerate for OUT_FILE, (eg. -f 30)", type: :numeric
-  method_option :resolution, aliases: "-r", desc: "Specify a resolution for OUT_FILE, (eg. -r 1920x1080)", type: :string
   def add_watermark(in_file, out_file)
     ProcessHelpers.resolution_require_value(options[:resolution])
     video = FFMPEG::Movie.new(in_file)
 
-    options = {
+    ffmpeg_options = {
       watermark: "assets/160-GA-Bitmaker-Glyph-Black.png",
       watermark_filter: { position: "RB", padding_x: 30, padding_y: 30 },
       resolution: options[:resolution] || "1920x1080",
       frame_rate: options[:framerate] || 30
     }
 
-    video.transcode(out_file, options)
+    video.transcode(out_file, ffmpeg_options)
   end
 
   desc "transcode IN_FILE OUT_FILE", "Transcode video file to mp4 format"
-  method_option :framerate, aliases: "-f", desc: "Specify a framerate for OUT_FILE, (eg. -f 30)", type: :numeric
-  method_option :resolution, aliases: "-r", desc: "Specify a resolution for OUT_FILE, (eg. -r 1920x1080)", type: :string
   def transcode(in_file, out_file)
     ProcessHelpers.resolution_require_value(options[:resolution])
     video = FFMPEG::Movie.new(in_file)
 
-    options = {
+    ffmpeg_options = {
       resolution: options[:resolution] || "1920x1080",
       frame_rate: options[:framerate] || 30
     }
 
-    video.transcode(out_file, options)
+    video.transcode(out_file, ffmpeg_options)
   end
 
   desc "concat FIRST_IN SECOND_IN OUT_FILE", "Concatenate two video files together"
-  method_option :framerate, aliases: "-f", desc: "Specify a framerate for OUT_FILE, (eg. -f 30)", type: :numeric
-  method_option :resolution, aliases: "-r", desc: "Specify a resolution for OUT_FILE, (eg. -r 1920x1080)", type: :string
   def concat(first_in, second_in, out_file)
     ProcessHelpers.resolution_require_value(options[:resolution])
 
@@ -68,5 +78,17 @@ class Screencastr < Thor
     [vs0][0:a][vs1][1:a] concat=n=2:v=1:a=1 [vout][aout]' \
     -r #{options[:framerate] || 30} \
     -map '[vout]' -map '[aout]' #{out_file}`
+  end
+
+  desc "brand IN_FILE OUT_FILE", "Transcode, watermark, and add bumpers, all in one command"
+  def brand(in_file, out_file)
+    ProcessHelpers.resolution_require_value(options[:resolution])
+    ext = File.extname(out_file)[1..-1]
+    invoke :add_watermark, [in_file, "watermarked.#{ext}"]
+    begin
+      invoke :add_bumpers, ["watermarked.#{ext}", out_file]
+    ensure
+      File.delete("watermarked.#{ext}") if File.exists?("watermarked.#{ext}")
+    end
   end
 end


### PR DESCRIPTION
Fixes #5.

So this fills in the `add_bumpers` task, and also adds a `brand` task that runs both `add_watermark` and `add_bumpers`.

I'll break down what I'm doing in comments below.