### PR TITLE
Add upload task, and upload option to brand task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ ruby '2.4.1'
 
 gem 'thor'
 gem 'pry'
+gem 'aws-sdk-s3', '~> 1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,21 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aws-partitions (1.45.0)
+    aws-sdk-core (3.11.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.3.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.8.0)
+      aws-sdk-core (~> 3)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.2)
     coderay (1.1.2)
+    jmespath (1.3.1)
     method_source (0.9.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -12,6 +26,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3 (~> 1)
   pry
   thor
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,25 @@ This is a Thor task that uses [`ffmpeg`](https://www.ffmpeg.org/) to transcode s
 
 Ideally this task will kick off automatically when a new video file is dropped into a watched folder.
 
-This project uses the [`streamio-ffmpeg`](https://github.com/streamio/streamio-ffmpeg) Ruby gem which wraps the ffmpeg library.
-
 ## Prerequisites
 
 You'll need to install the following cli tools on the system that you're running this task on:
 
-- ffmpeg (`brew install ffmpeg`)
++ ffmpeg (`brew install ffmpeg`)
 
+You'll also need to configure the following environment variables:
+
++ `AWS_ACCESS_KEY_ID` : Your access key ID for AWS
++ `AWS_SECRET_ACCESS_KEY` : Your secret access key for AWS
++ `AWS_REGION` : The AWS region, should probably be `us-east-1`
++ `BITMAKER_S3_BUCKET` : Optional, otherwise the bucket is set to `bitmakerhq`
 
 ## Transcoding Flow
 
 The process will be something like the following when done:
 
 1. Open video
-2. Transcode video down to preset settings (Fast 1080p30 in Handbrake)
+2. Transcode video down to preset settings
 3. Add watermark to video
 4. Encode bumper to same settings as video
   - Optionally, only if bumper video doesn't already exist on file system


### PR DESCRIPTION
Adds an `upload` task, and an upload option to the `brand` task.

`upload` takes two arguments, the input file and the output, including filepath on S3. By default, it uses **bitmakerhq** as the bucket, but will use whatever's in the `BITMAKER_S3_BUCKET` env var if its set.

The upload option on the `brand` task will just ask the user when they run it what the filename and filepath should be on S3, and invoke `upload` with the user's input as the `OUT_FILE` argument.

To use this, you need to have `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` env vars set, and optionally `BITMAKER_S3_BUCKET`.

@fightingtheboss Thoughts?